### PR TITLE
import Network.Socket instead of import Network

### DIFF
--- a/src/Network/Slack/Notifier.hs
+++ b/src/Network/Slack/Notifier.hs
@@ -24,7 +24,7 @@ import           Data.List
 import qualified Data.Map.Strict                       as M ()
 import qualified Data.Text                             as T
 import qualified Data.Text.Encoding                    as T
-import           Network
+import           Network.Socket
 import           Network.HTTP.Client
 import           Network.HTTP.Client.Internal          ()
 import           Network.HTTP.Client.MultipartFormData


### PR DESCRIPTION
Network 3.x no longer has a `Network` module which re-exports `Network.Socket`. So, just import `Network.Socket` directly. This should be backwards compatible.